### PR TITLE
ipairs -> pairs

### DIFF
--- a/Classes/Map/Elements/coreinstance.lua
+++ b/Classes/Map/Elements/coreinstance.lua
@@ -55,7 +55,7 @@ function EditorInstanceInputEvent:update(t, dt, instance_name)
 		return
 	end
 	local r, g, b = self._unit:mission_element()._color:unpack()
-	for i, data in ipairs(self._element.values.event_list) do
+	for i, data in pairs(self._element.values.event_list) do
 		if not self:_draw_instance_link(data.instance) then
 			table.remove(self._element.values.event_list, i)
 		end


### PR DESCRIPTION
Fix crash when using Instance elements.
`Application has crashed: C++ exception
...dLib-Editor-master/Classes/Map/Elements/coreinstance.lua:58: bad argument #1 to 'ipairs' (table expected, got nil)



SCRIPT STACK

update() @mods/BeardLib-Editor-master/Classes/Map/Elements/coreinstance.lua:58
update() @mods/BeardLib-Editor-master/Classes/Map/MissionEditor.lua:118
update() @mods/BeardLib-Editor-master/Classes/MapEditor.lua:673
func() @mods/BeardLib-Editor-master/Core.lua:441
Call() @mods/base/req/core/Hooks.lua:109
original() @mods/base/lua/GameSetup.lua:6
update() @mods/base/req/core/Hooks.lua:260
update() lib/setups/networkgamesetup.lua:21
core/lib/setups/coresetup.lua:556


-------------------------------

Callstack:

         payday2_win32_release  (???)     ???                                                 
         payday2_win32_release  (???)     zip_get_name                                        
         payday2_win32_release  (???)     zip_get_name                                        


-------------------------------

Current thread: Main

-------------------------------`