### PR TITLE
Added script data types/formats to editor

### DIFF
--- a/Classes/ScriptDataConverterManager.lua
+++ b/Classes/ScriptDataConverterManager.lua
@@ -134,7 +134,7 @@ function SConverter:RefreshFilesAndFolders()
             if self.assets and not PackageManager:has(extension:id(), (self.current_script_path .. file_parts[1]):id()) then
                 enabled = false
             end
-            if table.contains(BeardLib.config.script_data_types, extension) or table.contains(BeardLib.config.script_data_formats, extension) then
+            if table.contains(BLE.config.script_data_types, extension) or table.contains(BLE.config.script_data_formats, extension) then
                 filesgroup:button(file, ClassClbk(self, "FileClick"), {text = file, base_path = self.current_script_path .. file, enabled = enabled})
             end
         end

--- a/Core.lua
+++ b/Core.lua
@@ -33,6 +33,9 @@ function BLE:Init()
         LocalizationManager:add_localized_strings({BeardLibEditorMenu = "BeardLibEditor Menu"})
     end)
     Hooks:Add("MenuManagerPopulateCustomMenus", "BeardLibEditorInitManagers", ClassClbk(BLE, "InitManagers"))
+
+    self._config = FileIO:ReadConfig(self.ModPath.."main.xml", self)
+	self.config = self._config
 end
 
 function BLE:RunningFix()
@@ -238,7 +241,7 @@ function BLE:LoadHashlist()
     for _, pkg in pairs(CustomPackageManager.custom_packages) do
         local id = pkg.id
         self.DBPackages[id] = self.DBPackages[id] or {}
-        for _, type in pairs(table.list_add(clone(BeardLib.config.script_data_types), {"unit", "texture", "movie", "effect", "scene"})) do
+        for _, type in pairs(table.list_add(clone(BLE.config.script_data_types), {"unit", "texture", "movie", "effect", "scene"})) do
             self.DBPackages[id][type] = self.DBPackages[id][type] or {}
         end
         self:ReadCustomPackageConfig(id, pkg.config, pkg.dir)
@@ -272,7 +275,7 @@ end
 
 --Converts a list of packages - assets of packages to premade tables to be used in the editor
 function BLE:GeneratePackageData()
-    local types = table.list_add(clone(BeardLib.config.script_data_types), {"unit", "texture", "movie", "effect", "scene"})
+    local types = table.list_add(clone(BLE.config.script_data_types), {"unit", "texture", "movie", "effect", "scene"})
     local file = io.open(self.ModPath .. "packages.txt", "r")
     local packages_paths = {}
     local paths = {}

--- a/main.xml
+++ b/main.xml
@@ -383,4 +383,36 @@
     <AutoClassElements>
         <value_node value="ElementPickupCriminalDeployables"/>
     </AutoClassElements>
+    <script_data_types>
+        <value_node value="sequence_manager"/>
+        <value_node value="environment"/>
+        <value_node value="menu"/>
+        <value_node value="continent"/>
+        <value_node value="continents"/>
+        <value_node value="mission"/>
+        <value_node value="nav_data"/>
+        <value_node value="cover_data"/>
+        <value_node value="world"/>
+        <value_node value="world_cameras"/>
+        <value_node value="prefhud"/>
+        <value_node value="objective"/>
+        <value_node value="credits"/>
+        <value_node value="hint"/>
+        <value_node value="comment"/>
+        <value_node value="dialog"/>
+        <value_node value="dialog_index"/>
+        <value_node value="timeline"/>
+        <value_node value="action_message"/>
+        <value_node value="achievment"/>
+        <value_node value="controller_settings"/>
+        <value_node value="network_settings"/>
+        <value_node value="physics_settings"/>
+    </script_data_types>
+    <script_data_formats>
+        <value_node value="json"/>
+        <value_node value="xml"/>
+        <value_node value="generic_xml"/>
+        <value_node value="custom_xml"/>
+        <value_node value="binary"/>
+    </script_data_formats>
 </mod>


### PR DESCRIPTION
Used to be in Beardlib itself but was removed in a recent commit and doesn't seem to be used for anything outside of editor, if I'm mistaken this can be ignored and add the script data types/format to beardlib's main.xml instead

Fixes #500 