### PR TITLE
Fix a Linux crash from capitalisation

### DIFF
--- a/main.xml
+++ b/main.xml
@@ -61,7 +61,7 @@
 			<class file="WorldDataEditor.lua"/>
 			<class file="EditUnitEditableGui.lua"/>
 			<class file="EditLadder.lua"/>
-			<class file="EditZipLine.lua"/>
+			<class file="EditZipline.lua"/>
 			<class file="EditUnitLight.lua"/>
 			<class file="MissionScriptEditor.lua"/>
 			<class file="LayerEditor.lua"/>


### PR DESCRIPTION
Fix EditZipline.lua being mis-capitalised in the main.xml file, causing the editor to crash on Linux.