### PR TITLE
RelativeTeleport and RelativeTeleportTarget

### DIFF
--- a/Classes/Map/Elements/ElementRelativeTeleport.lua
+++ b/Classes/Map/Elements/ElementRelativeTeleport.lua
@@ -2,11 +2,13 @@ EditorRelativeTeleport = EditorRelativeTeleport or class(MissionScriptEditor)
 function EditorRelativeTeleport:create_element()
 	self.super.create_element(self)
 	self._element.class = "ElementRelativeTeleport"
-	self._element.values.elements = {}
+	self._element.values.target = {}
 end
 
 function EditorRelativeTeleport:_build_panel()
 	self:_create_panel()
 
-	self:BuildElementsManage("elements", nil, {"ElementRelativeTeleportTarget"})
+	self:BuildElementsManage("target", nil, {"ElementRelativeTeleportTarget"}, nil, {
+		single_select = true
+	})
 end

--- a/Classes/Map/Elements/ElementRelativeTeleport.lua
+++ b/Classes/Map/Elements/ElementRelativeTeleport.lua
@@ -1,0 +1,12 @@
+EditorRelativeTeleport = EditorRelativeTeleport or class(MissionScriptEditor)
+function EditorRelativeTeleport:create_element()
+	self.super.create_element(self)
+	self._element.class = "ElementRelativeTeleport"
+	self._element.values.elements = {}
+end
+
+function EditorRelativeTeleport:_build_panel()
+	self:_create_panel()
+
+	self:BuildElementsManage("elements", nil, {"ElementRelativeTeleportTarget"})
+end

--- a/Classes/Map/Elements/ElementRelativeTeleportTarget.lua
+++ b/Classes/Map/Elements/ElementRelativeTeleportTarget.lua
@@ -1,0 +1,5 @@
+EditorRelativeTeleportTarget = EditorRelativeTeleportTarget or class(MissionScriptEditor)
+function EditorRelativeTeleportTarget:create_element()
+	self.super.create_element(self)
+	self._element.class = "ElementRelativeTeleportTarget"
+end

--- a/main.xml
+++ b/main.xml
@@ -248,6 +248,8 @@
 	    <value_node value="ElementXAudio"/>
         <value_node value="ElementXAudioOperator"/>
 	    <value_node value="ElementBLCustomAchievement"/>
+        <value_node value="ElementRelativeTeleport"/>
+        <value_node value="ElementRelativeTeleportTarget"/>
         
         <!--Normal-->
         <value_node value="ElementSideJobAward"/>
@@ -287,7 +289,7 @@
         <value_node value="ElementRandomInstanceInputEvent"/>
         <value_node value="ElementInstanceOutput"/>
         <value_node value="ElementInstanceOutputEvent"/>
-	<value_node value="ElementRandomInstanceOutputEvent"/>
+        <value_node value="ElementRandomInstanceOutputEvent"/>
         <value_node value="ElementInstancePoint"/>
         <value_node value="ElementInstanceSetParams"/>
         <value_node value="ElementShape"/>


### PR DESCRIPTION
Two custom elements that allow instigators to be teleported based on their relative position to the element, this can be used to produce almost seamless teleports between areas.