### PR TITLE
Utilize grid for initial object placement

### DIFF
--- a/Classes/MapEditor.lua
+++ b/Classes/MapEditor.lua
@@ -968,6 +968,10 @@ function Editor:draw_marker(t, dt)
                 end
             end
         end
+	local grid = self._grid_size
+        mvector3.set_x(pos, math.floor(pos.x / grid) * grid)
+        mvector3.set_y(pos, math.floor(pos.y / grid) * grid)
+        mvector3.set_z(pos, math.floor(pos.z / grid) * grid)
     end
     self._spawn_position = pos
 end


### PR DESCRIPTION
Something I found quite weird was the grid setting not affecting unit/element placement, only movement once it's placed. This change affects the initial position which I think could be quite useful and the original behavior can still be achieved by holding down CTRL. Any opinions on this are welcome.