### PR TITLE
Fix error strings in level list

### DIFF
--- a/Classes/LoadLevelMenu.lua
+++ b/Classes/LoadLevelMenu.lua
@@ -174,7 +174,7 @@ function LoadLevelMenu:do_load_narratives()
 	end
 	for narr_id, narr in pairs(tweak_data.narrative.jobs) do
         if not narr.hidden and ((narr.custom and custom) or (not narr.custom and vanilla)) then
-            local txt = loc:text((narr.name_id or ("heist_"..narr_id:gsub("_prof", ""):gsub("_night", ""))) .." / " .. narr_id)
+            local txt = loc:text((narr.name_id or ("heist_"..narr_id:gsub("_prof", ""):gsub("_night", "")))) .." / " .. narr_id
             local texture, rect = nil, nil
 
 			if narr.contract_visuals and narr.contract_visuals.preview_image then


### PR DESCRIPTION
Bracket placements do be wild