### PR TITLE
PlaySound / Dialogue element improvements

### DIFF
--- a/Classes/ExportUtils.lua
+++ b/Classes/ExportUtils.lua
@@ -102,6 +102,7 @@ function Utils:GetDependencies(ext, path, ignore_default, exclude, extra_info)
         return false
 	end
 
+
     local dyn = managers.dyn_resource
     local temp = deep_clone(config)
     config = {}
@@ -412,12 +413,19 @@ function Utils:ReadEnvironment(path, config, exclude, extra_info)
 	return tbl ~= nil
 end
 
+function Utils:ReadSoundbank(path, config, exclude, extra_info)
+    extra_info.load = false
+    self:AddForceLoaded(config, "bnk", path, exclude, extra_info)
+    return true
+end
+
 Utils.Reading = {
     unit = Utils.ReadUnit,
 	scene = Utils.ReadScene,
 	environment = Utils.ReadEnvironment,
     object = Utils.ReadObject,
     effect = Utils.ReadEffect,
+    bnk = Utils.ReadSoundbank,
     material_config = Utils.ReadMaterialConfig,
     sequence_manager = Utils.ReadSequenceManager,
     animation_def = Utils.ReadAnimationDefintion,

--- a/Classes/ExportUtils.lua
+++ b/Classes/ExportUtils.lua
@@ -32,14 +32,14 @@ function Utils:init(config)
 end
 
 function Utils:Add(config, ext, path, exclude, extra_info)
-	if (exclude and exclude[ext]) or (not self._load_settings.base_assets and EditorUtils:InAllPackage(path, ext)) then
+	if (exclude and exclude[ext]) or (not self._load_settings.base_assets and ext ~= "bnk" and EditorUtils:InAllPackage(path, ext)) then
         return
     end
     table.insert(config, {_meta = ext, path = path, extra_info = self.pack_extra_info and extra_info or nil})
 end
 
 function Utils:AddForceLoaded(config, ext, path, exclude, extra_info)
-    if (exclude and exclude[ext]) or (not self._load_settings.base_assets and EditorUtils:InAllPackage(path, ext)) then
+    if (exclude and exclude[ext]) or (not self._load_settings.base_assets and ext ~= "bnk" and EditorUtils:InAllPackage(path, ext)) then
         return
     end
     table.insert(config, {_meta = ext, path = path, load = true, extra_info = self.pack_extra_info and extra_info or nil})
@@ -98,7 +98,7 @@ function Utils:GetDependencies(ext, path, ignore_default, exclude, extra_info)
     extra_info = extra_info or {}
 	local config = {}
 
-	if (not self._load_settings.base_assets and EditorUtils:InAllPackage(path, ext)) or (Utils.Reading[ext] and not Utils.Reading[ext](self, path, config, exclude, extra_info)) then
+	if (not self._load_settings.base_assets and ext ~= "bnk" and EditorUtils:InAllPackage(path, ext)) or (Utils.Reading[ext] and not Utils.Reading[ext](self, path, config, exclude, extra_info)) then
         return false
 	end
 

--- a/Classes/Map/Elements/coreplaysound.lua
+++ b/Classes/Map/Elements/coreplaysound.lua
@@ -39,6 +39,7 @@ function EditorPlaySound:_build_panel()
 	self:tickbox("Play on select", callback(self, self, "clbk_toggle_test_on_select"), true, {
 		help = "Whether to play the event when selecting it in the combobox"
 	})
+	self._test_on_select = true
 end
 
 function EditorPlaySound:test_element()
@@ -83,6 +84,7 @@ end
 
 function EditorPlaySound:clbk_bank_sound_id_selected(item)
 	self._element.values.sound_event = item:SelectedItem()
+	
 	if self._test_on_select then
 		self:test_element()
 	end

--- a/Classes/Map/Elements/coreplaysound.lua
+++ b/Classes/Map/Elements/coreplaysound.lua
@@ -36,6 +36,9 @@ function EditorPlaySound:_build_panel()
         searchbox = true, 
 	})
 	self._bank_sound_id_combobox:SetEnabled(false)
+	self:tickbox("Play on select", callback(self, self, "clbk_toggle_test_on_select"), true, {
+		help = "Whether to play the event when selecting it in the combobox"
+	})
 end
 
 function EditorPlaySound:test_element()
@@ -80,7 +83,14 @@ end
 
 function EditorPlaySound:clbk_bank_sound_id_selected(item)
 	self._element.values.sound_event = item:SelectedItem()
-	self:test_element()
+	if self._test_on_select then
+		self:test_element()
+	end
+end
+
+function EditorPlaySound:clbk_toggle_test_on_select(item)
+	self._test_on_select = item:Value()
+	self:stop_test_element()
 end
 
 function EditorPlaySound:destroy()

--- a/Classes/Map/Elements/coreplaysound.lua
+++ b/Classes/Map/Elements/coreplaysound.lua
@@ -9,14 +9,33 @@ function EditorPlaySound:create_element()
 	self._element.values.interrupt = true
 	self._element.values.use_play_func = false
 end
+
 function EditorPlaySound:_build_panel()
 	self:_create_panel()
 	self:BuildElementsManage("elements", nil, self.ELEMENT_FILTER)
-	self:StringCtrl("sound_event", {text = "Sound ID"})
+
+	self._manual_sound_id_strctrl = self:StringCtrl("sound_event", {text = "Sound ID"})
 	self:BooleanCtrl("append_prefix", {help = "Append unit prefix"})
 	self:BooleanCtrl("use_instigator", {help = "Play on instigator"})
 	self:BooleanCtrl("interrupt", {help = "Interrupt existing sound"})
 	self:BooleanCtrl("use_play_func", {help = "Use 'play' function in unit sound extension instead of 'say'"})
+	
+	local banks = {}
+	for bank, _ in pairs(Global.WwiseBanks) do
+		table.insert(banks, bank)
+	end
+	table.sort(banks)
+
+	self:combobox("Soundbank", callback(self, self, "clbk_soundbank_selected"), banks, nil, {
+		help = "Vanilla Wwise soundbank to filter available sound IDs to those contained inside it; leave blank to enter the ID manually. Selecting a soundbank will load it automatically",
+		searchbox = true
+	})
+	self._bank_sound_id_combobox = self:combobox("Bank Sound ID", callback(self, self, "clbk_bank_sound_id_selected"), nil, nil, {
+		help = "The event to use from the selected bank",
+		not_close = true, 
+        searchbox = true, 
+	})
+	self._bank_sound_id_combobox:SetEnabled(false)
 end
 
 function EditorPlaySound:test_element()
@@ -43,6 +62,25 @@ function EditorPlaySound:stop_test_element()
 	if self._ss then
 		self._ss:stop()
 	end
+end
+
+local assets = managers.editor.parts.assets
+function EditorPlaySound:clbk_soundbank_selected(item)
+	self._manual_sound_id_strctrl:SetEnabled(false)
+	self._soundbank = item:SelectedItem()
+
+	if not assets:is_asset_loaded("bnk", "soundbanks/" .. self._soundbank) then
+		assets:quick_load_from_db("bnk", "soundbanks/" .. self._soundbank, nil, nil, {load = true})
+	end
+
+	self._bank_sound_id_combobox:SetEnabled(true)
+	self._bank_sound_id_combobox:SetValue("")
+	self._bank_sound_id_combobox:SetItems(Global.WwiseBanks[self._soundbank]["events"] or {"No events in this bank!"})
+end
+
+function EditorPlaySound:clbk_bank_sound_id_selected(item)
+	self._element.values.sound_event = item:SelectedItem()
+	self:test_element()
 end
 
 function EditorPlaySound:destroy()

--- a/Classes/Map/Elements/dialogueelement.lua
+++ b/Classes/Map/Elements/dialogueelement.lua
@@ -46,6 +46,7 @@ function EditorDialogue:_build_panel()
         searchbox = true, 
         fit_text = true,
 		on_callback = function(item) 
+			self:check_load_dialogue_soundbank(item)
             self:set_element_data(item)
             self:test_element(item)
         end, 
@@ -57,4 +58,16 @@ function EditorDialogue:_build_panel()
 	self:BooleanCtrl("use_instigator", {help = "Play on instigator"})
 	self:BooleanCtrl("can_not_be_muted", {help = "This dialogue will play regardless of if the player has disabled contractor VO"})
 	self:BooleanCtrl("play_on_player_instigator_only", {help = "This dialogue will only play on the player that triggers it"})
+end
+function EditorDialogue:check_load_dialogue_soundbank(item)
+	local dialogue = string.gsub(string.gsub(item:SelectedItem(), "Play_", ""), "Stop_", "")
+	local assets = managers.editor.parts.assets
+
+	for bank,_ in pairs(Global.WwiseBanks) do
+		if Global.WwiseBanks[bank]["events"] then
+			if table.contains(Global.WwiseBanks[bank]["events"], "Play_" .. dialogue) and not assets:is_asset_loaded("bnk", "soundbanks/" .. bank) then
+				assets:quick_load_from_db("bnk", "soundbanks/" .. bank, nil, nil, {load = true})
+			end
+		end
+	end
 end

--- a/Classes/Utils.lua
+++ b/Classes/Utils.lua
@@ -457,7 +457,8 @@ end
 
 function Utils:InAllPackage(asset, type, packages)
     for name, package in pairs(packages or BLE.DBPackages) do
-        if name:begins("all_") and package[type] and package[type][asset] then
+        -- Soundbanks are a lovely exception, in that they need loading through dyn_resource. excluding them for dynamic PlaySound loading
+        if name:begins("all_") and package[type] and package[type][asset] and not type == "bnk" then
             return true
         end
     end

--- a/Classes/Utils.lua
+++ b/Classes/Utils.lua
@@ -457,8 +457,7 @@ end
 
 function Utils:InAllPackage(asset, type, packages)
     for name, package in pairs(packages or BLE.DBPackages) do
-        -- Soundbanks are a lovely exception, in that they need loading through dyn_resource. excluding them for dynamic PlaySound loading
-        if name:begins("all_") and package[type] and package[type][asset] and not type == "bnk" then
+        if name:begins("all_") and package[type] and package[type][asset] then
             return true
         end
     end

--- a/Core.lua
+++ b/Core.lua
@@ -278,6 +278,7 @@ function BLE:LoadHashlist()
         self.WorldSounds = Global.WorldSounds
         self.DefaultAssets = Global.DefaultAssets
         self.Brushes = Global.Brushes
+        self.WwiseBanks = Global.WwiseBanks
         self:log("DBPaths already loaded")
 	else
         self.DBPaths = FileIO:ReadScriptData(Path:Combine(self.DataDirectory, "Paths.bin"), "binary")
@@ -285,6 +286,7 @@ function BLE:LoadHashlist()
         self.WorldSounds = FileIO:ReadScriptData(Path:Combine(self.DataDirectory, "WorldSounds.bin"), "binary")
         self.Brushes = string.split(FileIO:ReadFrom(Path:Combine(self.DataDirectory, "Brushes.txt"), "r"), "\n")
         self.DefaultAssets = FileIO:ReadScriptData(Path:Combine(self.DataDirectory, "DefaultAssets.bin"), "binary")
+        self.WwiseBanks = FileIO:ReadScriptData(Path:Combine(self.DataDirectory, "WwiseBanks.bin"), "binary")
 
         self:log("Successfully loaded DBPaths, It took %.2f seconds", os.clock() - t)
         Global.DBPaths = self.DBPaths
@@ -292,6 +294,7 @@ function BLE:LoadHashlist()
         Global.WorldSounds = self.WorldSounds
         Global.DefaultAssets = self.DefaultAssets
         Global.Brushes = self.Brushes
+        Global.WwiseBanks = self.WwiseBanks
     end
     local script_data_types = clone(self._config.script_data_types)
     for _, pkg in pairs(CustomPackageManager.custom_packages) do


### PR DESCRIPTION
This adds filtering functionality to the PlaySound element, so that by selecting a vanilla bnk, it is automatically loaded and added to AddFiles, and its events presented in a combobox. Additionally, the editor loads the neccesary bnk when selecting an unloaded dialogue.

https://streamable.com/vzoqej

This should **not** be pushed unless the editor datafiles are updated with the Wwise string list. My process was to convert the following file, [WwiseBanks.json](https://github.com/user-attachments/files/26363524/WwiseBanks.json), into ScriptData, and then to name it `WwiseBanks.bin`.
