### PR TITLE
Generate mipmaps for cubelights

### DIFF
--- a/Tools/cubemap_light.bat
+++ b/Tools/cubemap_light.bat
@@ -12,7 +12,7 @@ rem CubeMapGen -exportFilename:%7 -exportPixelFormat:A8R8G8B8 -exportMipChain -i
 
 rem CubeMapGen -exportFilename:%7 -exportPixelFormat:A8R8G8B8 -exportSize:64 -exportMipChain -importFaceXPos:%1 -importFaceXNeg:%2 -importFaceYPos:%3 -importFaceYNeg:%4 -importFaceZPos:%5 -importFaceZNeg:%6 -exportCubeDDS -exit
 
-"%~dp0\CubeMapGen.exe" -exportFilename:%7 -numFilterThreads:2 -exportPixelFormat:DXT5 -exportSize:%8 -filterTech:AngularGaussian -baseFilterAngle:10 -initialMipFilterAngle:0 -perLevelMipFilterScale:0 -edgeFixupTech:HermiteAverage -edgeFixupWidth:1 -solidAngleWeighting -importFaceXPos:%1 -importFaceXNeg:%2 -importFaceYPos:%3 -importFaceYNeg:%4 -importFaceZPos:%5 -importFaceZNeg:%6 -exportCubeDDS -exit
+"%~dp0\CubeMapGen.exe" -exportFilename:%7 -numFilterThreads:2 -exportPixelFormat:DXT5 -exportSize:%8 -exportMipChain -filterTech:AngularGaussian -baseFilterAngle:10 -initialMipFilterAngle:0 -perLevelMipFilterScale:0 -edgeFixupTech:HermiteAverage -edgeFixupWidth:1 -solidAngleWeighting -importFaceXPos:%1 -importFaceXNeg:%2 -importFaceYPos:%3 -importFaceYNeg:%4 -importFaceZPos:%5 -importFaceZNeg:%6 -exportCubeDDS -exit
 
 
 popd


### PR DESCRIPTION
The omni light shader uses mipmaps to smooth out specularity from the cubelight texture and they were not already being generated.

Translated omni shader hlsl to demonstrate:
```c
#if defined(PROJECTION)
	float4 sample_pos;
	sample_pos.xyz = reflect(look_vector, normal_s.xyz);
	sample_pos.w = (1.0 - normal_s.w) * 4.0;

	specular_color += texCUBElod(ref_light_texture, sample_pos).xyz;
#endif
```